### PR TITLE
Do not wrap download link in an button element

### DIFF
--- a/exportdb/templates/exportdb/in_progress.html
+++ b/exportdb/templates/exportdb/in_progress.html
@@ -39,7 +39,7 @@
 
 
     <div class="submit-row" style="display: none;">
-        <button><a href="#" id="download-link">{% trans "Download export file" %}</a></button>
+        <a href="#" id="download-link" class="button default">{% trans "Download export file" %}</a>
     </div>
 </div>
 


### PR DESCRIPTION
This is not valid html and specifically disallowed, besides (and that is
the reason for this change, it does not work in firefox).

Also adds button and default class to the link, to make the styling consistent with
the rest of the admin.
